### PR TITLE
feat(client): provide ssrFixStacktrace to client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -600,7 +600,7 @@ export class ViteNodeRunner {
 
   /**
    * mutate the given error to have fixed stacktraces based on source maps
-   * similar to Vite's ssrFixStacktrace
+   * Does the same thing as Vite's ssrFixStacktrace
    */
   async ssrFixStacktrace(error: Error): Promise<Error> {
     const stack = (error.stack || '').split('\n')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

Hey :wave: 

Small PR following https://github.com/nuxt/nuxt/pull/33989 . This allows to fix a stacktrace outside of vite's execution context.
The issue is that vite's `ssrFixStacktrace` uses an offset with `new Function(${ode})` on all stacktraces lines. which is not needed in nitro/vite-node context so users will most of the time see the staxktrace pointing to the compiled line instead of the source file's line.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->

### Linked Issues

https://github.com/nuxt/nuxt/issues/33917

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
